### PR TITLE
backends: render template fully once to establish context

### DIFF
--- a/invenio_notifications/backends/utils/loaders.py
+++ b/invenio_notifications/backends/utils/loaders.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
+# Copyright (C) 2023 CERN.
 # Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Notifications is free software; you can redistribute it and/or modify it
@@ -39,8 +40,14 @@ class JinjaTemplateLoaderMixin:
             {
                 "notification": notification,
                 "recipient": recipient,
-            }
+            },
         )
+
+        # "Force" rendering the whole template (including global variables).
+        # Since we render block by block afterwards, the context and variables
+        # would be lost between blocks.
+        list(template.root_render_func(ctx))
+
         return {
             block: "".join(
                 block_func(ctx)


### PR DESCRIPTION


:heart: Thank you for your contribution!

### Description

resolves https://github.com/inveniosoftware/invenio-rdm-records/issues/1179

~~Add an explicit `ctx` variable to be available in the template. The goal is to provide a variable template blocks can extend, without having to touch the `notification`  or `recipient` variable (i.e. prevent unintentional overrides). As the blocks are executed one after the other, there is no outer scope provided, so setting general variables in a template used by other blocks takes no effect. A template can now specify a first block, which just sets values in the `ctx`variable (e.g. [review submission](https://github.com/inveniosoftware/invenio-rdm-records/pull/990/files#diff-fa62af9205ce9159411f04b10582e7ff2c469d55494f5201b2a93298ea94c770R3-R12))~~

Render template fully once to establish context and set global variables. This allows block by block rendering to access prior introduced variables.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
