### PR TITLE
generators: skip resolved entity on permission denied error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changes
 =======
 
 
+Version <next>
+
+- generators: skip resolved entity on permission denied error
+
 Version 1.0.0 (release 2024-12-10)
 
 - setup: bump major dependencies

--- a/invenio_notifications/services/generators.py
+++ b/invenio_notifications/services/generators.py
@@ -11,6 +11,7 @@
 from abc import ABC, abstractmethod
 
 from invenio_records.dictutils import dict_lookup, dict_set
+from invenio_records_resources.services.errors import PermissionDeniedError
 
 from invenio_notifications.backends.email import EmailNotificationBackend
 from invenio_notifications.registry import EntityResolverRegistry
@@ -74,9 +75,14 @@ class EntityResolve(ContextGenerator):
 
     def __call__(self, notification):
         """Update required recipient information and add backend id."""
-        entity_ref = dict_lookup(notification.context, self.key)
-        entity = EntityResolverRegistry.resolve_entity(entity_ref)
-        dict_set(notification.context, self.key, entity)
+        try:
+            entity_ref = dict_lookup(notification.context, self.key)
+            entity = EntityResolverRegistry.resolve_entity(entity_ref)
+            dict_set(notification.context, self.key, entity)
+        except PermissionDeniedError:
+            # The users service masks "not found" with "permission denied" for privacy
+            pass
+
         return notification
 
 


### PR DESCRIPTION
The users service masks "not found" results with "permission denied" errors, to avoid leaking information about certain users not existing.
This also happens for the "system" entity, which causes the notifications to break if the system adds a comment.

This PR handles "permission denied" errors more gracefully by simply skipping the offending entity.