### PR TITLE
fix: setuptools compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,19 +84,19 @@ testpaths = docs tests invenio_notifications
 
 [compile_catalog]
 directory = invenio_notifications/translations/
-use-fuzzy = True
+use_fuzzy = True
 
 [extract_messages]
 copyright_holder = CERN
 msgid_bugs_address = info@inveniosoftware.org
-mapping-file = babel.ini
-output-file = invenio_notifications/translations/messages.pot
-add-comments = NOTE
+mapping_file = babel.ini
+output_file = invenio_notifications/translations/messages.pot
+add_comments = NOTE
 
 [init_catalog]
-input-file = invenio_notifications/translations/messages.pot
-output-dir = invenio_notifications/translations/
+input_file = invenio_notifications/translations/messages.pot
+output_dir = invenio_notifications/translations/
 
 [update_catalog]
-input-file = invenio_notifications/translations/messages.pot
-output-dir = invenio_notifications/translations/
+input_file = invenio_notifications/translations/messages.pot
+output_dir = invenio_notifications/translations/


### PR DESCRIPTION
### Description

Setuptools do not recognize '-' in options anymore - only '_' are recognized. This PR changes babel options (such as mapping-file) to underscores.
